### PR TITLE
[feat] 시작하기 화면 구현

### DIFF
--- a/iOS-BaroIntern-LeeMyungji/App/AppDelegate.swift
+++ b/iOS-BaroIntern-LeeMyungji/App/AppDelegate.swift
@@ -14,47 +14,24 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
         return true
     }
 
     // MARK: UISceneSession Lifecycle
 
     func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
-        // Called when a new scene session is being created.
-        // Use this method to select a configuration to create the new scene with.
         return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
     }
 
     func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
-        // Called when the user discards a scene session.
-        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
-        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
 
     // MARK: - Core Data stack
-
+    
     lazy var persistentContainer: NSPersistentContainer = {
-        /*
-         The persistent container for the application. This implementation
-         creates and returns a container, having loaded the store for the
-         application to it. This property is optional since there are legitimate
-         error conditions that could cause the creation of the store to fail.
-        */
         let container = NSPersistentContainer(name: "iOS_BaroIntern_LeeMyungji")
         container.loadPersistentStores(completionHandler: { (storeDescription, error) in
             if let error = error as NSError? {
-                // Replace this implementation with code to handle the error appropriately.
-                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
-                 
-                /*
-                 Typical reasons for an error here include:
-                 * The parent directory does not exist, cannot be created, or disallows writing.
-                 * The persistent store is not accessible, due to permissions or data protection when the device is locked.
-                 * The device is out of space.
-                 * The store could not be migrated to the current model version.
-                 Check the error message to determine what the actual problem was.
-                 */
                 fatalError("Unresolved error \(error), \(error.userInfo)")
             }
         })
@@ -69,8 +46,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             do {
                 try context.save()
             } catch {
-                // Replace this implementation with code to handle the error appropriately.
-                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
                 let nserror = error as NSError
                 fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
             }

--- a/iOS-BaroIntern-LeeMyungji/App/SceneDelegate.swift
+++ b/iOS-BaroIntern-LeeMyungji/App/SceneDelegate.swift
@@ -13,43 +13,19 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
-        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
-        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
-        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
-        guard let _ = (scene as? UIWindowScene) else { return }
-    }
+        guard let windowScene = (scene as? UIWindowScene) else { return }
+        
+        let window = UIWindow(windowScene: windowScene)
+        
 
-    func sceneDidDisconnect(_ scene: UIScene) {
-        // Called as the scene is being released by the system.
-        // This occurs shortly after the scene enters the background, or when its session is discarded.
-        // Release any resources associated with this scene that can be re-created the next time the scene connects.
-        // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
-    }
-
-    func sceneDidBecomeActive(_ scene: UIScene) {
-        // Called when the scene has moved from an inactive state to an active state.
-        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
-    }
-
-    func sceneWillResignActive(_ scene: UIScene) {
-        // Called when the scene will move from an active state to an inactive state.
-        // This may occur due to temporary interruptions (ex. an incoming phone call).
-    }
-
-    func sceneWillEnterForeground(_ scene: UIScene) {
-        // Called as the scene transitions from the background to the foreground.
-        // Use this method to undo the changes made on entering the background.
+        window.rootViewController = StartViewController()
+        window.makeKeyAndVisible()
+        
+        self.window = window
     }
 
     func sceneDidEnterBackground(_ scene: UIScene) {
-        // Called as the scene transitions from the foreground to the background.
-        // Use this method to save data, release shared resources, and store enough scene-specific state information
-        // to restore the scene back to its current state.
-
-        // Save changes in the application's managed object context when the application transitions to the background.
         (UIApplication.shared.delegate as? AppDelegate)?.saveContext()
     }
-
-
 }
 

--- a/iOS-BaroIntern-LeeMyungji/Controller/StartViewController.swift
+++ b/iOS-BaroIntern-LeeMyungji/Controller/StartViewController.swift
@@ -1,0 +1,36 @@
+//
+//  StartViewController.swift
+//  iOS-BaroIntern-LeeMyungji
+//
+//  Created by 이명지 on 3/14/25.
+//
+
+import UIKit
+
+final class StartViewController: UIViewController {
+    private let startButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("시작하기", for: .normal)
+        button.setTitleColor(.white, for: .normal)
+        button.backgroundColor = .systemBlue
+        button.layer.cornerRadius = 15
+        return button
+    }()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+    }
+    
+    private func setupUI() {
+        view.addSubview(startButton)
+        
+        startButton.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            startButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            startButton.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            startButton.widthAnchor.constraint(equalToConstant: 150),
+            startButton.heightAnchor.constraint(equalToConstant: 60)
+        ])
+    }
+}

--- a/iOS-BaroIntern-LeeMyungji/Controller/StartViewController.swift
+++ b/iOS-BaroIntern-LeeMyungji/Controller/StartViewController.swift
@@ -7,6 +7,10 @@
 
 import UIKit
 
+private struct UserDefaultsKeys {
+    static let isLoggedIn = "isLoggedIn"
+}
+
 final class StartViewController: UIViewController {
     private let startButton: UIButton = {
         let button = UIButton()
@@ -32,5 +36,19 @@ final class StartViewController: UIViewController {
             startButton.widthAnchor.constraint(equalToConstant: 150),
             startButton.heightAnchor.constraint(equalToConstant: 60)
         ])
+        
+        startButton.addTarget(self, action: #selector(startButtonTapped), for: .touchUpInside)
+    }
+    
+    @objc private func startButtonTapped() {
+        guard isLoggedIn() else {
+            // 회원가입 화면으로 이동
+            return
+        }
+        // 로그인 성공 화면으로 이동
+    }
+    
+    private func isLoggedIn() -> Bool {
+        return UserDefaults.standard.bool(forKey: UserDefaultsKeys.isLoggedIn)
     }
 }

--- a/iOS-BaroIntern-LeeMyungji/Controller/StartViewController.swift
+++ b/iOS-BaroIntern-LeeMyungji/Controller/StartViewController.swift
@@ -23,20 +23,35 @@ final class StartViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        setupUI()
+        setupSubviews()
+        setupConstraints()
+        setupActions()
     }
     
-    private func setupUI() {
-        view.addSubview(startButton)
+    private func setupSubviews() {
+        [
+            startButton
+        ].forEach {
+            view.addSubview($0)
+        }
+    }
+    
+    private func setupConstraints() {
+        [
+            startButton
+        ].forEach {
+            $0.translatesAutoresizingMaskIntoConstraints = false
+        }
         
-        startButton.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             startButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             startButton.centerYAnchor.constraint(equalTo: view.centerYAnchor),
             startButton.widthAnchor.constraint(equalToConstant: 150),
             startButton.heightAnchor.constraint(equalToConstant: 60)
         ])
-        
+    }
+    
+    private func setupActions() {
         startButton.addTarget(self, action: #selector(startButtonTapped), for: .touchUpInside)
     }
     


### PR DESCRIPTION
## 📝 요약(Summary)

- 시작하기 화면 UI 완성
- 유저디폴트에 저장된 로그인 여부 Bool 값으로 회원/비회원 구분

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

<img src="https://github.com/user-attachments/assets/e2011332-1aff-4907-8a73-b8a72df24149" width="300">

## 💬 공유사항 to 리뷰어

- 유저디폴트 키값을 관리하는 UserDefaultsKeys 구조체를 정의해 키값을 static으로 사용할 수 있도록 했습니다.
- `StartViewController.swift`에서 시작하기 버튼을 누르고 화면을 이동하는 부분은 추후 각 화면 구현 후에 이동 코드를 추가해야합니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
